### PR TITLE
Implement Context7 memory helpers with MagicMCP fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Atendor is a modern SaaS platform for creating personal AI assistants.
 - Supabase authentication and storage
 - DaisyUI styled components with TailwindCSS
 - Simple bot creation and training
-- Chat interface with Context7 memory
+- Chat interface with Context7 memory (falls back to MagicMCP)
 
 ## Getting Started
 1. Install dependencies
@@ -22,6 +22,9 @@ Atendor is a modern SaaS platform for creating personal AI assistants.
    CONTEXT7_API_KEY=
    OPENROUTER_API_KEY=
    ```
+   `CONTEXT7_API_KEY` is used by the memory helpers to store and retrieve
+   conversations. When Context7 is unavailable, the helpers automatically
+   fall back to MagicMCP.
 3. Run the development server
    ```bash
    npm run dev

--- a/lib/memory.ts
+++ b/lib/memory.ts
@@ -1,3 +1,53 @@
-export async function saveMemory() {
-  // TODO integrate Context7 or MagicMCP
+import { Message } from '@/types/message';
+
+const CONTEXT7_ENDPOINT = 'https://api.context7.com/v1/memory';
+const MAGICMCP_ENDPOINT = 'https://api.magicmcp.com/v1/memory';
+
+async function callApi(
+  url: string,
+  body: Record<string, unknown> | undefined,
+  key?: string,
+  method = 'POST'
+) {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  if (key) {
+    headers['Authorization'] = `Bearer ${key}`;
+  }
+
+  const res = await fetch(url, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  if (!res.ok) {
+    throw new Error(`Request failed: ${res.status}`);
+  }
+
+  return res.json();
+}
+
+export async function saveMemory(botId: string, messages: Message[]) {
+  const body = { botId, messages };
+  const key = process.env.CONTEXT7_API_KEY;
+
+  try {
+    return await callApi(`${CONTEXT7_ENDPOINT}/save`, body, key);
+  } catch (err) {
+    console.error('Context7 unavailable, falling back to MagicMCP');
+    return callApi(`${MAGICMCP_ENDPOINT}/save`, body);
+  }
+}
+
+export async function fetchMemory(botId: string): Promise<Message[]> {
+  const key = process.env.CONTEXT7_API_KEY;
+
+  try {
+    return await callApi(`${CONTEXT7_ENDPOINT}/fetch/${botId}`, undefined, key, 'GET');
+  } catch (err) {
+    console.error('Context7 unavailable, falling back to MagicMCP');
+    return callApi(`${MAGICMCP_ENDPOINT}/fetch/${botId}`, undefined, undefined, 'GET');
+  }
 }


### PR DESCRIPTION
## Summary
- add saveMemory and fetchMemory helpers for conversation history
- use CONTEXT7_API_KEY and fall back to MagicMCP if needed
- document memory env var usage and fallback behaviour

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: pnpm required for magicui dependency)*

------
https://chatgpt.com/codex/tasks/task_e_684041cf5a90832480c027c52611b610