### PR TITLE
Implement bot training form

### DIFF
--- a/app/api/train/route.ts
+++ b/app/api/train/route.ts
@@ -1,5 +1,16 @@
 import { NextResponse } from 'next/server';
 
-export async function POST() {
-  return NextResponse.json({ message: 'train endpoint' });
+export async function POST(req: Request) {
+  try {
+    const { text } = await req.json();
+
+    if (!text) {
+      return NextResponse.json({ error: 'Missing text' }, { status: 400 });
+    }
+
+    // TODO: handle training logic
+    return NextResponse.json({ message: 'Training received' });
+  } catch {
+    return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+  }
 }

--- a/app/bots/page.tsx
+++ b/app/bots/page.tsx
@@ -1,3 +1,10 @@
+import BotTrainer from '@/components/BotTrainer';
+
 export default function Bots() {
-  return <div>Bots</div>;
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Bots</h1>
+      <BotTrainer />
+    </div>
+  );
 }

--- a/components/BotTrainer.tsx
+++ b/components/BotTrainer.tsx
@@ -1,8 +1,54 @@
+"use client";
+
+import { useState, FormEvent } from 'react';
+
 export default function BotTrainer() {
+  const [text, setText] = useState("");
+  const [status, setStatus] = useState<"idle" | "success" | "error" | "loading">(
+    "idle"
+  );
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setStatus("loading");
+
+    try {
+      const res = await fetch("/api/train", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ text }),
+      });
+
+      if (res.ok) {
+        setStatus("success");
+        setText("");
+      } else {
+        setStatus("error");
+      }
+    } catch (err) {
+      setStatus("error");
+    }
+  }
+
   return (
-    <form className="space-y-4">
-      <textarea className="textarea textarea-bordered w-full" placeholder="Paste training text" />
-      <button type="submit" className="btn btn-primary">Train</button>
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <textarea
+        className="textarea textarea-bordered w-full"
+        placeholder="Paste training text"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+      />
+      <button type="submit" className="btn btn-primary" disabled={status === "loading"}>
+        {status === "loading" ? "Training..." : "Train"}
+      </button>
+      {status === "success" && (
+        <p className="text-success">Training uploaded successfully!</p>
+      )}
+      {status === "error" && (
+        <p className="text-error">Failed to upload training text.</p>
+      )}
     </form>
   );
 }


### PR DESCRIPTION
## Summary
- add client form state for bot training
- send training data to `/api/train`
- display training results to user
- wire the trainer into the bots page
- accept text body in the `/api/train` route

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: uses pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_684041cc88e08324bd1c088541c7d529