### PR TITLE
Add chat UI with message state

### DIFF
--- a/app/api/bot/route.ts
+++ b/app/api/bot/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 
-export async function POST() {
-  return NextResponse.json({ message: 'bot endpoint' });
+export async function POST(request: Request) {
+  const { text } = await request.json();
+  return NextResponse.json({ message: `You said: ${text}` });
 }

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -1,3 +1,47 @@
+'use client'
+
+import { useState } from 'react';
+import ChatBubble from '@/components/ChatBubble';
+import MessageInput from '@/components/MessageInput';
+import { Message } from '@/types/message';
+
 export default function Chat() {
-  return <div>Chat</div>;
+  const [messages, setMessages] = useState<Message[]>([]);
+
+  const sendMessage = async (text: string) => {
+    const userMsg: Message = {
+      id: Date.now().toString(),
+      text,
+      from: 'user',
+    };
+    setMessages((prev) => [...prev, userMsg]);
+
+    try {
+      const res = await fetch('/api/bot', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text }),
+      });
+      const data = await res.json();
+      const botMsg: Message = {
+        id: crypto.randomUUID(),
+        text: data.message,
+        from: 'bot',
+      };
+      setMessages((prev) => [...prev, botMsg]);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div className="flex h-screen flex-col p-4">
+      <div className="mb-2 flex-1 space-y-2 overflow-y-auto">
+        {messages.map((m) => (
+          <ChatBubble key={m.id} text={m.text} from={m.from} />
+        ))}
+      </div>
+      <MessageInput onSend={sendMessage} />
+    </div>
+  );
 }

--- a/components/ChatBubble.tsx
+++ b/components/ChatBubble.tsx
@@ -1,5 +1,13 @@
-export default function ChatBubble({ text, from }: { text: string; from: 'user' | 'bot' }) {
+export default function ChatBubble({
+  text,
+  from,
+}: {
+  text: string;
+  from: 'user' | 'bot';
+}) {
   return (
-    <div className={`chat-bubble ${from === 'user' ? 'chat-end' : 'chat-start'}`}>{text}</div>
+    <div className={`chat ${from === 'user' ? 'chat-end' : 'chat-start'}`}>
+      <div className="chat-bubble">{text}</div>
+    </div>
   );
 }

--- a/components/MessageInput.tsx
+++ b/components/MessageInput.tsx
@@ -1,8 +1,31 @@
-export default function MessageInput() {
+import { FormEvent, useState } from 'react';
+
+export default function MessageInput({
+  onSend,
+}: {
+  onSend: (text: string) => void;
+}) {
+  const [text, setText] = useState('');
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    if (!text.trim()) return;
+    onSend(text);
+    setText('');
+  };
+
   return (
-    <form className="flex gap-2">
-      <input type="text" placeholder="Type a message" className="input input-bordered flex-1" />
-      <button type="submit" className="btn btn-primary">Send</button>
+    <form onSubmit={handleSubmit} className="flex gap-2">
+      <input
+        type="text"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        placeholder="Type a message"
+        className="input input-bordered flex-1"
+      />
+      <button type="submit" className="btn btn-primary">
+        Send
+      </button>
     </form>
   );
 }


### PR DESCRIPTION
## Summary
- implement `ChatBubble` layout with DaisyUI classes
- add stateful `MessageInput` component that calls a callback
- build a simple chat page that shows a scrollable history and posts to `/api/bot`
- echo user text in `/api/bot` for testing

## Testing
- `pnpm install`
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_684041cb7d5c83248a541c3c8bd9f068