### PR TITLE
Add bot management via Supabase

### DIFF
--- a/app/bots/page.tsx
+++ b/app/bots/page.tsx
@@ -1,3 +1,86 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import BotCard from '@/components/BotCard';
+import { supabase } from '@/lib/supabase';
+import type { Bot } from '@/types/bot';
+
 export default function Bots() {
-  return <div>Bots</div>;
+  const [bots, setBots] = useState<Bot[]>([]);
+  const [name, setName] = useState('');
+  const [personality, setPersonality] = useState('');
+  const [purpose, setPurpose] = useState('');
+
+  useEffect(() => {
+    async function loadBots() {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user) return;
+      const { data } = await supabase
+        .from('bots')
+        .select('*')
+        .eq('user_id', user.id);
+      if (data) setBots(data as Bot[]);
+    }
+    loadBots();
+  }, []);
+
+  async function createBot() {
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return;
+    const { data, error } = await supabase
+      .from('bots')
+      .insert({ name, personality, purpose, user_id: user.id })
+      .select()
+      .single();
+    if (!error && data) {
+      setBots([...bots, data as Bot]);
+      setName('');
+      setPersonality('');
+      setPurpose('');
+    }
+  }
+
+  return (
+    <div className="max-w-xl mx-auto space-y-4 p-4">
+      <form
+        className="space-y-2"
+        onSubmit={(e) => {
+          e.preventDefault();
+          createBot();
+        }}
+      >
+        <input
+          type="text"
+          className="input input-bordered w-full"
+          placeholder="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <textarea
+          className="textarea textarea-bordered w-full"
+          placeholder="Personality"
+          value={personality}
+          onChange={(e) => setPersonality(e.target.value)}
+        />
+        <textarea
+          className="textarea textarea-bordered w-full"
+          placeholder="Purpose"
+          value={purpose}
+          onChange={(e) => setPurpose(e.target.value)}
+        />
+        <button type="submit" className="btn btn-primary">
+          Create Bot
+        </button>
+      </form>
+      <div className="grid gap-4">
+        {bots.map((bot) => (
+          <BotCard key={bot.id} bot={bot} />
+        ))}
+      </div>
+    </div>
+  );
 }

--- a/components/BotCard.tsx
+++ b/components/BotCard.tsx
@@ -1,3 +1,11 @@
-export default function BotCard() {
-  return <div className="p-4 border rounded">BotCard</div>;
+import type { Bot } from '@/types/bot';
+
+export default function BotCard({ bot }: { bot: Bot }) {
+  return (
+    <div className="p-4 border rounded space-y-1">
+      <h2 className="text-lg font-semibold">{bot.name}</h2>
+      {bot.personality && <p className="text-sm">{bot.personality}</p>}
+      {bot.purpose && <p className="text-sm text-gray-600">{bot.purpose}</p>}
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- fetch user's bots from Supabase
- render a list of `BotCard` entries
- allow creating new bots with a simple form

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684041ca516883248035f7db513288cf