### PR TITLE
Add Supabase auth pages

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,52 @@
+'use client';
+import { useState, FormEvent } from 'react';
+import { useRouter } from 'next/navigation';
+import { supabase } from '@/lib/supabase';
+
+export default function Login() {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    const { error } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    });
+    if (error) {
+      setError(error.message);
+    } else {
+      router.push('/dashboard');
+    }
+  };
+
+  return (
+    <main className="flex min-h-screen items-center justify-center">
+      <form onSubmit={handleSubmit} className="w-80 space-y-4">
+        <input
+          className="input input-bordered w-full"
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <input
+          className="input input-bordered w-full"
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        {error && <p className="text-red-500">{error}</p>}
+        <button type="submit" className="btn btn-primary w-full">
+          Login
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,0 +1,52 @@
+'use client';
+import { useState, FormEvent } from 'react';
+import { useRouter } from 'next/navigation';
+import { supabase } from '@/lib/supabase';
+
+export default function Signup() {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    const { error } = await supabase.auth.signUp({
+      email,
+      password,
+    });
+    if (error) {
+      setError(error.message);
+    } else {
+      router.push('/dashboard');
+    }
+  };
+
+  return (
+    <main className="flex min-h-screen items-center justify-center">
+      <form onSubmit={handleSubmit} className="w-80 space-y-4">
+        <input
+          className="input input-bordered w-full"
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <input
+          className="input input-bordered w-full"
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        {error && <p className="text-red-500">{error}</p>}
+        <button type="submit" className="btn btn-primary w-full">
+          Sign Up
+        </button>
+      </form>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add login page with Supabase `signInWithPassword`
- add signup page with Supabase `signUp`
- redirect both to `/dashboard` on success

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68404199723483249ae617185b5fbd04