### PR TITLE
Add Node setup to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20.x
+          cache: 'pnpm'
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - run: pnpm install
+      - run: pnpm run build


### PR DESCRIPTION
## Summary
- add `.github/workflows/ci.yml` with `actions/setup-node@v3`

## Testing
- `pnpm install`
- `pnpm run lint` *(fails: requires interactive input)*
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_684078b42d4c83248cee9907edc0b952