### PR TITLE
Pin date-fns to stable 2.29

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "tailwind-merge": "^2.2.2",
-    "geist": "^1.4.2"
+    "geist": "^1.4.2",
+    "date-fns": "2.29.3"
   },
   "devDependencies": {
     "@types/react": "19.1.6",
@@ -30,5 +31,10 @@
     "tailwindcss": "^3.4.1",
     "tailwindcss-animate": "^1.0.7",
     "typescript": "^5.4.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "date-fns": "2.29.3"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  date-fns: 2.29.3
+
 importers:
 
   .:
@@ -20,6 +23,9 @@ importers:
       daisyui:
         specifier: ^4.9.0
         version: 4.12.24(postcss@8.5.4)
+      date-fns:
+        specifier: 2.29.3
+        version: 2.29.3
       geist:
         specifier: ^1.4.2
         version: 1.4.2(next@14.1.0(@babel/core@7.27.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
@@ -175,10 +181,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-
-  '@babel/runtime@7.27.4':
-    resolution: {integrity: sha512-t3yaEOuGu9NlIZ+hIeGbBjFtZT7j2cb2tg0fuaJKeGotchRjjLfrBA9Kwf8quhpP1EUuxModQg04q/mBwyg8uA==}
-    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.27.2':
     resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
@@ -1757,8 +1759,8 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
-  date-fns@2.30.0:
-    resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
+  date-fns@2.29.3:
+    resolution: {integrity: sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==}
     engines: {node: '>=0.11'}
 
   debug@3.2.7:
@@ -3082,7 +3084,7 @@ packages:
   react-day-picker@8.10.1:
     resolution: {integrity: sha512-TMx7fNbhLk15eqcMt+7Z7S2KF7mfTId/XJDjKE8f+IUcFn0l08/kI4FiYTL/0yuOLmEcbR4Fwe3GJf/NiiMnPA==}
     peerDependencies:
-      date-fns: ^2.28.0 || ^3.0.0
+      date-fns: 2.29.3
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
 
   react-dom@18.2.0:
@@ -3889,8 +3891,6 @@ snapshots:
       '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.27.4)
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/runtime@7.27.4': {}
 
   '@babel/template@7.27.2':
     dependencies:
@@ -5527,9 +5527,7 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
-  date-fns@2.30.0:
-    dependencies:
-      '@babel/runtime': 7.27.4
+  date-fns@2.29.3: {}
 
   debug@3.2.7:
     dependencies:
@@ -6582,7 +6580,7 @@ snapshots:
       concurrently: 9.1.2
       crisp-sdk-web: 1.0.25
       critters: 0.0.24
-      date-fns: 2.30.0
+      date-fns: 2.29.3
       geist: 1.4.2(next@14.1.0(@babel/core@7.27.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       gray-matter: 4.0.3
       jotai: 2.12.5(@types/react@19.1.6)(react@18.3.1)
@@ -6596,7 +6594,7 @@ snapshots:
       postcss: 8.4.39
       posthog-js: 1.249.3
       react: 18.3.1
-      react-day-picker: 8.10.1(date-fns@2.30.0)(react@18.3.1)
+      react-day-picker: 8.10.1(date-fns@2.29.3)(react@18.3.1)
       react-dom: 18.3.1(react@18.3.1)
       react-hook-form: 7.57.0(react@18.3.1)
       react-tweet: 3.2.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -7052,9 +7050,9 @@ snapshots:
 
   raf-schd@4.0.3: {}
 
-  react-day-picker@8.10.1(date-fns@2.30.0)(react@18.3.1):
+  react-day-picker@8.10.1(date-fns@2.29.3)(react@18.3.1):
     dependencies:
-      date-fns: 2.30.0
+      date-fns: 2.29.3
       react: 18.3.1
 
   react-dom@18.2.0(react@18.2.0):


### PR DESCRIPTION
## Summary
- override `date-fns` to use version `2.29.3`
- update `pnpm-lock.yaml`

## Testing
- `pnpm lint` *(fails: prompts for config)*

------
https://chatgpt.com/codex/tasks/task_e_684078b768bc83249b1ed9941c8bcf14