### PR TITLE
Fix outdated pnpm lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       date-fns:
         specifier: 2.29.3
         version: 2.29.3
+      framer-motion:
+        specifier: ^11.0.0
+        version: 11.18.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       geist:
         specifier: ^1.4.2
         version: 1.4.2(next@14.1.0(@babel/core@7.27.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
@@ -6010,6 +6013,15 @@ snapshots:
       fetch-blob: 3.2.0
 
   fraction.js@4.3.7: {}
+
+  framer-motion@11.18.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+    dependencies:
+      motion-dom: 11.18.1
+      motion-utils: 11.18.1
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
 
   framer-motion@11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:


### PR DESCRIPTION
## Summary
- update pnpm-lock.yaml so that framer-motion is included

## Testing
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_684094ea1fe48324a99f8c409056212b