### PR TITLE
Add animated hero and BentoGrid

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,25 +1,52 @@
+"use client";
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
 import { FlickeringGrid } from '@/components/magicui/flickering-grid';
-import { TextReveal } from '@/components/magicui/text-reveal';
+import { BentoGrid, BentoGridItem } from '@/components/magicui/bento-grid';
 
 export default function Home() {
+  const [theme, setTheme] = useState<'light' | 'dark'>('light');
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+  }, [theme]);
+
   return (
     <main className="flex min-h-screen flex-col">
       {/* Hero */}
-      <section className="hero relative flex-1 bg-base-200 py-20">
-        <FlickeringGrid />
-        <div className="hero-content text-center relative z-10">
+      <section className="hero relative flex-1 overflow-hidden bg-base-200 py-20">
+        <FlickeringGrid className="absolute inset-0 -z-10 opacity-20" />
+        <div className="relative z-10 hero-content text-center">
           <div className="max-w-md space-y-4">
             <h1 className="text-5xl font-bold">Atendor</h1>
             <p className="py-2 text-lg">
-              Crea asistentes de IA personalizados para tu negocio
+              Create personalized AI assistants for your business
             </p>
             <Link href="/signup" className="btn btn-primary">
-              Comienza gratis
+              Get started free
             </Link>
           </div>
         </div>
       </section>
+
+      <div className="my-16 px-4">
+        <BentoGrid>
+          <BentoGridItem
+            title="Serve clients 24/7"
+            description="Let your assistant respond at any time"
+            icon="\uD83D\uDD0C"
+          />
+          <BentoGridItem
+            title="Train your AI assistant in seconds"
+            description="Upload docs or links and you're done"
+            icon="\u23F3"
+          />
+          <BentoGridItem
+            title="Personal support tailored to your business"
+            description="Your data powers unique responses"
+            icon="\uD83E\uDD1D"
+          />
+        </BentoGrid>
+      </div>
 
       {/* How it works */}
       <section className="container mx-auto my-16 px-4">
@@ -75,6 +102,12 @@ export default function Home() {
             Dashboard
           </Link>
         </nav>
+        <button
+          className="btn btn-sm"
+          onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
+        >
+          {theme === 'light' ? 'Dark' : 'Light'} mode
+        </button>
       </footer>
     </main>
   );

--- a/components/magicui/bento-grid.tsx
+++ b/components/magicui/bento-grid.tsx
@@ -1,0 +1,58 @@
+"use client";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { ReactNode, HTMLAttributes } from "react";
+
+export interface BentoGridProps extends HTMLAttributes<HTMLDivElement> {}
+
+export function BentoGrid({ className, ...props }: BentoGridProps) {
+  return (
+    <div
+      className={cn(
+        "mx-auto grid w-full max-w-5xl grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export interface BentoGridItemProps extends HTMLAttributes<HTMLDivElement> {
+  title: string;
+  description: string;
+  icon?: ReactNode;
+  href?: string;
+  cta?: string;
+}
+
+export function BentoGridItem({
+  title,
+  description,
+  icon,
+  href,
+  cta = "Learn more",
+  className,
+  ...props
+}: BentoGridItemProps) {
+  const content = (
+    <div
+      className={cn(
+        "flex h-full flex-col justify-between overflow-hidden rounded-xl bg-base-100 p-6 shadow",
+        className,
+      )}
+      {...props}
+    >
+      {icon && <div className="text-4xl">{icon}</div>}
+      <h3 className="mt-4 text-xl font-semibold">{title}</h3>
+      <p className="mb-4 text-base-content/70">{description}</p>
+      {href && (
+        <Link href={href} className="btn btn-sm btn-ghost w-max">
+          {cta}
+          <ArrowRight className="ms-1 h-4 w-4" />
+        </Link>
+      )}
+    </div>
+  );
+  return content;
+}

--- a/components/magicui/flickering-grid.tsx
+++ b/components/magicui/flickering-grid.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+interface FlickeringGridProps extends React.HTMLAttributes<HTMLDivElement> {
+  squareSize?: number;
+  gridGap?: number;
+  flickerChance?: number;
+  color?: string;
+  width?: number;
+  height?: number;
+  className?: string;
+  maxOpacity?: number;
+}
+
+export const FlickeringGrid: React.FC<FlickeringGridProps> = ({
+  squareSize = 4,
+  gridGap = 6,
+  flickerChance = 0.3,
+  color = "rgb(0, 0, 0)",
+  width,
+  height,
+  className,
+  maxOpacity = 0.3,
+  ...props
+}) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [isInView, setIsInView] = useState(false);
+  const [canvasSize, setCanvasSize] = useState({ width: 0, height: 0 });
+
+  const memoizedColor = useMemo(() => {
+    const toRGBA = (color: string) => {
+      if (typeof window === "undefined") {
+        return `rgba(0, 0, 0,`;
+      }
+      const canvas = document.createElement("canvas");
+      canvas.width = canvas.height = 1;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) return "rgba(255, 0, 0,";
+      ctx.fillStyle = color;
+      ctx.fillRect(0, 0, 1, 1);
+      const [r, g, b] = Array.from(ctx.getImageData(0, 0, 1, 1).data);
+      return `rgba(${r}, ${g}, ${b},`;
+    };
+    return toRGBA(color);
+  }, [color]);
+
+  const setupCanvas = useCallback(
+    (canvas: HTMLCanvasElement, width: number, height: number) => {
+      const dpr = window.devicePixelRatio || 1;
+      canvas.width = width * dpr;
+      canvas.height = height * dpr;
+      canvas.style.width = `${width}px`;
+      canvas.style.height = `${height}px`;
+      const cols = Math.floor(width / (squareSize + gridGap));
+      const rows = Math.floor(height / (squareSize + gridGap));
+
+      const squares = new Float32Array(cols * rows);
+      for (let i = 0; i < squares.length; i++) {
+        squares[i] = Math.random() * maxOpacity;
+      }
+
+      return { cols, rows, squares, dpr };
+    },
+    [squareSize, gridGap, maxOpacity],
+  );
+
+  const updateSquares = useCallback(
+    (squares: Float32Array, deltaTime: number) => {
+      for (let i = 0; i < squares.length; i++) {
+        if (Math.random() < flickerChance * deltaTime) {
+          squares[i] = Math.random() * maxOpacity;
+        }
+      }
+    },
+    [flickerChance, maxOpacity],
+  );
+
+  const drawGrid = useCallback(
+    (
+      ctx: CanvasRenderingContext2D,
+      width: number,
+      height: number,
+      cols: number,
+      rows: number,
+      squares: Float32Array,
+      dpr: number,
+    ) => {
+      ctx.clearRect(0, 0, width, height);
+      ctx.fillStyle = "transparent";
+      ctx.fillRect(0, 0, width, height);
+
+      for (let i = 0; i < cols; i++) {
+        for (let j = 0; j < rows; j++) {
+          const opacity = squares[i * rows + j];
+          ctx.fillStyle = `${memoizedColor}${opacity})`;
+          ctx.fillRect(
+            i * (squareSize + gridGap) * dpr,
+            j * (squareSize + gridGap) * dpr,
+            squareSize * dpr,
+            squareSize * dpr,
+          );
+        }
+      }
+    },
+    [memoizedColor, squareSize, gridGap],
+  );
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const container = containerRef.current;
+    if (!canvas || !container) return;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    let animationFrameId: number;
+    let gridParams: ReturnType<typeof setupCanvas>;
+
+    const updateCanvasSize = () => {
+      const newWidth = width || container.clientWidth;
+      const newHeight = height || container.clientHeight;
+      setCanvasSize({ width: newWidth, height: newHeight });
+      gridParams = setupCanvas(canvas, newWidth, newHeight);
+    };
+
+    updateCanvasSize();
+
+    let lastTime = 0;
+    const animate = (time: number) => {
+      if (!isInView) return;
+
+      const deltaTime = (time - lastTime) / 1000;
+      lastTime = time;
+
+      updateSquares(gridParams.squares, deltaTime);
+      drawGrid(
+        ctx,
+        canvas.width,
+        canvas.height,
+        gridParams.cols,
+        gridParams.rows,
+        gridParams.squares,
+        gridParams.dpr,
+      );
+      animationFrameId = requestAnimationFrame(animate);
+    };
+
+    const resizeObserver = new ResizeObserver(() => {
+      updateCanvasSize();
+    });
+
+    resizeObserver.observe(container);
+
+    const intersectionObserver = new IntersectionObserver(
+      ([entry]) => {
+        setIsInView(entry.isIntersecting);
+      },
+      { threshold: 0 },
+    );
+
+    intersectionObserver.observe(canvas);
+
+    if (isInView) {
+      animationFrameId = requestAnimationFrame(animate);
+    }
+
+    return () => {
+      cancelAnimationFrame(animationFrameId);
+      resizeObserver.disconnect();
+      intersectionObserver.disconnect();
+    };
+  }, [setupCanvas, updateSquares, drawGrid, width, height, isInView]);
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn(`h-full w-full ${className}`)}
+      {...props}
+    >
+      <canvas
+        ref={canvasRef}
+        className="pointer-events-none"
+        style={{
+          width: canvasSize.width,
+          height: canvasSize.height,
+        }}
+      />
+    </div>
+  );
+};

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
## Summary
- add utility `cn` helper
- pull in Magic UI components for `FlickeringGrid` and new `BentoGrid`
- update landing page hero with animated background, BentoGrid section, and dark mode toggle

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6840acdbf01883249bf150cd216f32f1