### PR TITLE
Improve BentoGrid layout

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,13 @@ import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { FlickeringGrid } from '@/components/magicui/flickering-grid';
 import { BentoGrid, BentoGridItem } from '@/components/magicui/bento-grid';
+import {
+  AlarmClock,
+  UploadCloud,
+  Handshake,
+  Settings,
+  Plug,
+} from 'lucide-react';
 
 export default function Home() {
   const [theme, setTheme] = useState<'light' | 'dark'>('light');
@@ -31,19 +38,31 @@ export default function Home() {
       <div className="my-16 px-4">
         <BentoGrid>
           <BentoGridItem
+            className="sm:col-span-2 sm:row-span-2"
             title="Serve clients 24/7"
             description="Let your assistant respond at any time"
-            icon="\uD83D\uDD0C"
+            icon={<AlarmClock />}
           />
           <BentoGridItem
-            title="Train your AI assistant in seconds"
+            title="Train your assistant in seconds"
             description="Upload docs or links and you're done"
-            icon="\u23F3"
+            icon={<UploadCloud />}
           />
           <BentoGridItem
-            title="Personal support tailored to your business"
-            description="Your data powers unique responses"
-            icon="\uD83E\uDD1D"
+            title="Tailored support"
+            description="Your assistant learns your tone"
+            icon={<Handshake />}
+          />
+          <BentoGridItem
+            className="sm:col-span-2"
+            title="No coding required"
+            description="Setup easily with our dashboard"
+            icon={<Settings />}
+          />
+          <BentoGridItem
+            title="Seamless integrations"
+            description="Connect to your site with one script"
+            icon={<Plug />}
           />
         </BentoGrid>
       </div>

--- a/components/magicui/bento-grid.tsx
+++ b/components/magicui/bento-grid.tsx
@@ -1,8 +1,10 @@
 "use client";
 import Link from "next/link";
 import { ArrowRight } from "lucide-react";
+import { motion } from "framer-motion";
 import { cn } from "@/lib/utils";
 import type { ReactNode, HTMLAttributes } from "react";
+import type { HTMLMotionProps } from "framer-motion";
 
 export interface BentoGridProps extends HTMLAttributes<HTMLDivElement> {}
 
@@ -10,7 +12,7 @@ export function BentoGrid({ className, ...props }: BentoGridProps) {
   return (
     <div
       className={cn(
-        "mx-auto grid w-full max-w-5xl grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3",
+        "mx-auto grid w-full max-w-5xl auto-rows-[18rem] grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4",
         className,
       )}
       {...props}
@@ -18,7 +20,7 @@ export function BentoGrid({ className, ...props }: BentoGridProps) {
   );
 }
 
-export interface BentoGridItemProps extends HTMLAttributes<HTMLDivElement> {
+export interface BentoGridItemProps extends HTMLMotionProps<"div"> {
   title: string;
   description: string;
   icon?: ReactNode;
@@ -35,10 +37,14 @@ export function BentoGridItem({
   className,
   ...props
 }: BentoGridItemProps) {
-  const content = (
-    <div
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      whileHover={{ scale: 1.03 }}
       className={cn(
-        "flex h-full flex-col justify-between overflow-hidden rounded-xl bg-base-100 p-6 shadow",
+        "flex h-full flex-col justify-between overflow-hidden rounded-xl bg-base-100 p-6 shadow transition-all",
         className,
       )}
       {...props}
@@ -52,7 +58,6 @@ export function BentoGridItem({
           <ArrowRight className="ms-1 h-4 w-4" />
         </Link>
       )}
-    </div>
+    </motion.div>
   );
-  return content;
 }


### PR DESCRIPTION
## Summary
- animate BentoGrid items with framer-motion
- update grid to allow bento-style spans
- replace unicode strings with Lucide icons and add new cards

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6840b61b80f0832486b012e1f224ca73