### PR TITLE
Add global navigation and improved bot creation

### DIFF
--- a/app/admin/bots/page.tsx
+++ b/app/admin/bots/page.tsx
@@ -15,9 +15,6 @@ export default function AdminBots() {
           </li>
         ))}
       </ul>
-      <Link href="/admin" className="link">
-        Volver
-      </Link>
     </main>
   );
 }

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -15,9 +15,6 @@ export default function AdminUsers() {
           </li>
         ))}
       </ul>
-      <Link href="/admin" className="link">
-        Volver
-      </Link>
     </main>
   );
 }

--- a/app/bots/new/page.tsx
+++ b/app/bots/new/page.tsx
@@ -1,12 +1,24 @@
-'use client';
+"use client";
 import { useState } from 'react';
-import Link from 'next/link';
+import { ShimmerButton } from '@/components/magicui/shimmer-button';
+
+const personalities = ["Friendly", "Professional", "Cheerful", "Serious"];
 
 export default function NewBot() {
+  const [step, setStep] = useState(0);
   const [name, setName] = useState('');
   const [purpose, setPurpose] = useState('');
+  const [personality, setPersonality] = useState('Friendly');
+  const [training, setTraining] = useState('');
+  const [avatar, setAvatar] = useState('');
   const [saved, setSaved] = useState(false);
 
+  function next() {
+    setStep((s) => Math.min(s + 1, 3));
+  }
+  function back() {
+    setStep((s) => Math.max(s - 1, 0));
+  }
   function handleSave() {
     setSaved(true);
   }
@@ -14,32 +26,87 @@ export default function NewBot() {
   return (
     <main className="container mx-auto max-w-xl space-y-4 p-4">
       <h1 className="text-2xl font-bold">Crear Bot</h1>
-      <div className="form-control w-full space-y-2">
-        <input
-          type="text"
-          placeholder="Nombre"
-          className="input input-bordered w-full"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-        />
-        <textarea
-          placeholder="Propósito"
-          className="textarea textarea-bordered w-full"
-          value={purpose}
-          onChange={(e) => setPurpose(e.target.value)}
-        />
-        <button className="btn btn-primary" onClick={handleSave}>
-          Guardar
-        </button>
-        {saved && (
-          <div className="alert alert-success shadow-lg">
-            <span>Bot guardado (simulado)</span>
-          </div>
+      <ul className="steps w-full text-sm">
+        <li className={`step ${step >= 0 ? 'step-primary' : ''}`}>Info</li>
+        <li className={`step ${step >= 1 ? 'step-primary' : ''}`}>Personalidad</li>
+        <li className={`step ${step >= 2 ? 'step-primary' : ''}`}>Entrenamiento</li>
+        <li className={`step ${step >= 3 ? 'step-primary' : ''}`}>Avatar</li>
+      </ul>
+
+      {step === 0 && (
+        <div className="space-y-2">
+          <input
+            type="text"
+            placeholder="Nombre del bot"
+            className="input input-bordered w-full"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+          <textarea
+            placeholder="Propósito"
+            className="textarea textarea-bordered w-full"
+            value={purpose}
+            onChange={(e) => setPurpose(e.target.value)}
+          />
+        </div>
+      )}
+
+      {step === 1 && (
+        <div className="space-y-2">
+          <select
+            className="select select-bordered w-full"
+            value={personality}
+            onChange={(e) => setPersonality(e.target.value)}
+          >
+            {personalities.map((p) => (
+              <option key={p}>{p}</option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {step === 2 && (
+        <div className="space-y-2">
+          <textarea
+            className="textarea textarea-bordered w-full"
+            rows={6}
+            value={training}
+            onChange={(e) => setTraining(e.target.value)}
+            placeholder="Pega o escribe texto para entrenar"
+          />
+        </div>
+      )}
+
+      {step === 3 && (
+        <div className="space-y-2">
+          <input
+            type="text"
+            placeholder="URL de avatar o emoji"
+            className="input input-bordered w-full"
+            value={avatar}
+            onChange={(e) => setAvatar(e.target.value)}
+          />
+        </div>
+      )}
+
+      {saved && (
+        <div className="alert alert-success shadow-lg">
+          <span>Bot guardado (simulado)</span>
+        </div>
+      )}
+
+      <div className="flex justify-between pt-4">
+        {step > 0 && (
+          <button onClick={back} className="btn">
+            Atras
+          </button>
+        )}
+        {step < 3 ? (
+          <ShimmerButton onClick={next}>Siguiente</ShimmerButton>
+        ) : (
+          <ShimmerButton onClick={handleSave}>Guardar</ShimmerButton>
         )}
       </div>
-      <Link href="/bots" className="link">
-        Volver a bots
-      </Link>
     </main>
   );
 }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,42 +1,46 @@
 import Link from 'next/link';
 import { mockBots } from '@/lib/mock/bots';
 import { mockUsers } from '@/lib/mock/users';
+import DashboardSidebar from '@/components/DashboardSidebar';
 
 export default function Dashboard() {
   const user = mockUsers[0];
   return (
-    <main className="container mx-auto max-w-2xl space-y-8 p-4">
-      <h1 className="text-3xl font-bold">Hola, {user.name}</h1>
+    <main className="container mx-auto flex gap-4 p-4">
+      <DashboardSidebar />
+      <div className="flex-1 space-y-8">
+        <h1 className="text-3xl font-bold">Hola, {user.name}</h1>
 
-      <section>
-        <div className="mb-2 flex items-center justify-between">
-          <h2 className="text-xl font-semibold">Tus Bots</h2>
-          <Link href="/bots/new" className="btn btn-sm btn-primary">
-            Crear nuevo bot
-          </Link>
-        </div>
-        <ul className="space-y-2">
-          {mockBots.map((bot) => (
-            <li key={bot.id} className="card bg-base-100 shadow">
-              <div className="card-body flex-row items-center justify-between p-4">
-                <span>{bot.name}</span>
-                <Link href={`/bots/${bot.id}`} className="link-hover link">
-                  Ver
-                </Link>
-              </div>
-            </li>
-          ))}
-        </ul>
-      </section>
+        <section>
+          <div className="mb-2 flex items-center justify-between">
+            <h2 className="text-xl font-semibold">Tus Bots</h2>
+            <Link href="/bots/new" className="btn btn-sm btn-primary">
+              Crear nuevo bot
+            </Link>
+          </div>
+          <ul className="space-y-2">
+            {mockBots.map((bot) => (
+              <li key={bot.id} className="card bg-base-100 shadow">
+                <div className="card-body flex-row items-center justify-between p-4">
+                  <span>{bot.name}</span>
+                  <Link href={`/bots/${bot.id}`} className="link-hover link">
+                    Ver
+                  </Link>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
 
-      <section>
-        <h2 className="mb-2 text-xl font-semibold">Última interacción</h2>
-        <div className="rounded bg-base-200 p-4">
-          <p className="text-sm text-gray-600">
-            Tu bot respondió: &quot;¡Hola! ¿En qué puedo ayudarte?&quot;
-          </p>
-        </div>
-      </section>
+        <section>
+          <h2 className="mb-2 text-xl font-semibold">Última interacción</h2>
+          <div className="rounded bg-base-200 p-4">
+            <p className="text-sm text-gray-600">
+              Tu bot respondió: &quot;¡Hola! ¿En qué puedo ayudarte?&quot;
+            </p>
+          </div>
+        </section>
+      </div>
     </main>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import '../styles/globals.css';
 import type { ReactNode } from 'react';
 import { GeistSans } from 'geist/font/sans';
+import Header from '@/components/Header';
 
 export const metadata = {
   title: 'Atendor',
@@ -10,7 +11,10 @@ export const metadata = {
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body className={GeistSans.className}>{children}</body>
+      <body className={GeistSans.className}>
+        <Header />
+        {children}
+      </body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 import Link from 'next/link';
-import { useEffect, useState } from 'react';
+
 import { FlickeringGrid } from '@/components/magicui/flickering-grid';
 import { BentoGrid, BentoGridItem } from '@/components/magicui/bento-grid';
+import ThemeToggle from '@/components/ThemeToggle';
 import {
   AlarmClock,
   UploadCloud,
@@ -12,10 +13,6 @@ import {
 } from 'lucide-react';
 
 export default function Home() {
-  const [theme, setTheme] = useState<'light' | 'dark'>('light');
-  useEffect(() => {
-    document.documentElement.setAttribute('data-theme', theme);
-  }, [theme]);
 
   return (
     <main className="flex min-h-screen flex-col">
@@ -121,12 +118,7 @@ export default function Home() {
             Dashboard
           </Link>
         </nav>
-        <button
-          className="btn btn-sm"
-          onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
-        >
-          {theme === 'light' ? 'Dark' : 'Light'} mode
-        </button>
+        <ThemeToggle />
       </footer>
     </main>
   );

--- a/components/BackButton.tsx
+++ b/components/BackButton.tsx
@@ -1,0 +1,21 @@
+"use client";
+import { useRouter } from 'next/navigation';
+import { ArrowLeft } from 'lucide-react';
+import { ShineBorder } from '@/components/magicui/shine-border';
+import { cn } from '@/lib/utils';
+
+export default function BackButton({ className }: { className?: string }) {
+  const router = useRouter();
+  return (
+    <div className={cn('relative', className)}>
+      <ShineBorder className="rounded-md" shineColor={["#A07CFE", "#FE8FB5", "#FFBE7B"]} />
+      <button
+        onClick={() => router.back()}
+        className="btn btn-ghost btn-sm relative z-10 flex items-center gap-1"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back
+      </button>
+    </div>
+  );
+}

--- a/components/DashboardSidebar.tsx
+++ b/components/DashboardSidebar.tsx
@@ -1,0 +1,51 @@
+"use client";
+import Link from 'next/link';
+import { useState } from 'react';
+import { Menu, X } from 'lucide-react';
+import { motion, AnimatePresence } from 'framer-motion';
+
+const navItems = [
+  { href: '/dashboard', label: 'My Bots' },
+  { href: '/bots/new', label: 'Create Bot' },
+  { href: '/dashboard/settings', label: 'Settings' },
+  { href: '/help', label: 'Help / Feedback' },
+];
+
+export default function DashboardSidebar() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="relative sm:w-56">
+      <button
+        className="btn btn-ghost sm:hidden"
+        onClick={() => setOpen((o) => !o)}
+      >
+        {open ? <X /> : <Menu />}
+      </button>
+      <AnimatePresence>
+        {(open || typeof window === 'undefined') && (
+          <motion.aside
+            initial={{ x: -260 }}
+            animate={{ x: 0 }}
+            exit={{ x: -260 }}
+            transition={{ type: 'spring', stiffness: 260, damping: 20 }}
+            className="fixed inset-y-0 left-0 z-20 w-56 bg-base-100 p-4 shadow sm:static sm:translate-x-0"
+          >
+            <nav className="space-y-2">
+              {navItems.map((item) => (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className="block rounded px-2 py-2 transition hover:bg-base-200"
+                  onClick={() => setOpen(false)}
+                >
+                  {item.label}
+                </Link>
+              ))}
+            </nav>
+          </motion.aside>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,0 +1,43 @@
+"use client";
+import Link from 'next/link';
+import { useState } from 'react';
+import ThemeToggle from './ThemeToggle';
+import BackButton from './BackButton';
+import { AnimatedShinyText } from '@/components/magicui/animated-shiny-text';
+
+export default function Header() {
+  const [loggedIn] = useState(false);
+  return (
+    <header className="border-b bg-base-100">
+      <nav className="container mx-auto flex items-center justify-between p-4">
+        <div className="flex items-center gap-4">
+          <BackButton className="hidden sm:inline-flex" />
+          <Link href="/" className="font-bold">
+            <AnimatedShinyText className="text-2xl">Atendor</AnimatedShinyText>
+          </Link>
+        </div>
+        <div className="flex items-center gap-4">
+          <Link href="/" className="link-hover link">
+            Home
+          </Link>
+          <Link href="/dashboard" className="link-hover link">
+            Dashboard
+          </Link>
+          {loggedIn ? (
+            <button className="btn btn-sm">Logout</button>
+          ) : (
+            <>
+              <Link href="/login" className="link-hover link">
+                Login
+              </Link>
+              <Link href="/signup" className="link-hover link">
+                Sign Up
+              </Link>
+            </>
+          )}
+          <ThemeToggle />
+        </div>
+      </nav>
+    </header>
+  );
+}

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,0 +1,19 @@
+"use client";
+import { useEffect, useState } from 'react';
+
+export default function ThemeToggle() {
+  const [theme, setTheme] = useState<'light' | 'dark'>('light');
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+  }, [theme]);
+
+  return (
+    <button
+      className="btn btn-ghost btn-sm"
+      onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
+    >
+      {theme === 'light' ? 'Dark' : 'Light'} mode
+    </button>
+  );
+}

--- a/components/magicui/animated-shiny-text.tsx
+++ b/components/magicui/animated-shiny-text.tsx
@@ -1,0 +1,39 @@
+import { ComponentPropsWithoutRef, CSSProperties, FC } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface AnimatedShinyTextProps
+  extends ComponentPropsWithoutRef<"span"> {
+  shimmerWidth?: number;
+}
+
+export const AnimatedShinyText: FC<AnimatedShinyTextProps> = ({
+  children,
+  className,
+  shimmerWidth = 100,
+  ...props
+}) => {
+  return (
+    <span
+      style={
+        {
+          "--shiny-width": `${shimmerWidth}px`,
+        } as CSSProperties
+      }
+      className={cn(
+        "mx-auto max-w-md text-neutral-600/70 dark:text-neutral-400/70",
+
+        // Shine effect
+        "animate-shiny-text bg-clip-text bg-no-repeat [background-position:0_0] [background-size:var(--shiny-width)_100%] [transition:background-position_1s_cubic-bezier(.6,.6,0,1)_infinite]",
+
+        // Shine gradient
+        "bg-gradient-to-r from-transparent via-black/80 via-50% to-transparent  dark:via-white/80",
+
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </span>
+  );
+};

--- a/components/magicui/shimmer-button.tsx
+++ b/components/magicui/shimmer-button.tsx
@@ -1,0 +1,96 @@
+import React, { CSSProperties, ComponentPropsWithoutRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface ShimmerButtonProps extends ComponentPropsWithoutRef<"button"> {
+  shimmerColor?: string;
+  shimmerSize?: string;
+  borderRadius?: string;
+  shimmerDuration?: string;
+  background?: string;
+  className?: string;
+  children?: React.ReactNode;
+}
+
+export const ShimmerButton = React.forwardRef<
+  HTMLButtonElement,
+  ShimmerButtonProps
+>(
+  (
+    {
+      shimmerColor = "#ffffff",
+      shimmerSize = "0.05em",
+      shimmerDuration = "3s",
+      borderRadius = "100px",
+      background = "rgba(0, 0, 0, 1)",
+      className,
+      children,
+      ...props
+    },
+    ref,
+  ) => {
+    return (
+      <button
+        style={
+          {
+            "--spread": "90deg",
+            "--shimmer-color": shimmerColor,
+            "--radius": borderRadius,
+            "--speed": shimmerDuration,
+            "--cut": shimmerSize,
+            "--bg": background,
+          } as CSSProperties
+        }
+        className={cn(
+          "group relative z-0 flex cursor-pointer items-center justify-center overflow-hidden whitespace-nowrap border border-white/10 px-6 py-3 text-white [background:var(--bg)] [border-radius:var(--radius)] dark:text-black",
+          "transform-gpu transition-transform duration-300 ease-in-out active:translate-y-px",
+          className,
+        )}
+        ref={ref}
+        {...props}
+      >
+        {/* spark container */}
+        <div
+          className={cn(
+            "-z-30 blur-[2px]",
+            "absolute inset-0 overflow-visible [container-type:size]",
+          )}
+        >
+          {/* spark */}
+          <div className="absolute inset-0 h-[100cqh] animate-shimmer-slide [aspect-ratio:1] [border-radius:0] [mask:none]">
+            {/* spark before */}
+            <div className="absolute -inset-full w-auto rotate-0 animate-spin-around [background:conic-gradient(from_calc(270deg-(var(--spread)*0.5)),transparent_0,var(--shimmer-color)_var(--spread),transparent_var(--spread))] [translate:0_0]" />
+          </div>
+        </div>
+        {children}
+
+        {/* Highlight */}
+        <div
+          className={cn(
+            "insert-0 absolute size-full",
+
+            "rounded-2xl px-4 py-1.5 text-sm font-medium shadow-[inset_0_-8px_10px_#ffffff1f]",
+
+            // transition
+            "transform-gpu transition-all duration-300 ease-in-out",
+
+            // on hover
+            "group-hover:shadow-[inset_0_-6px_10px_#ffffff3f]",
+
+            // on click
+            "group-active:shadow-[inset_0_-10px_10px_#ffffff3f]",
+          )}
+        />
+
+        {/* backdrop */}
+        <div
+          className={cn(
+            "absolute -z-20 [background:var(--bg)] [border-radius:var(--radius)] [inset:var(--cut)]",
+          )}
+        />
+      </button>
+    );
+  },
+);
+
+ShimmerButton.displayName = "ShimmerButton";

--- a/components/magicui/shine-border.tsx
+++ b/components/magicui/shine-border.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+interface ShineBorderProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * Width of the border in pixels
+   * @default 1
+   */
+  borderWidth?: number;
+  /**
+   * Duration of the animation in seconds
+   * @default 14
+   */
+  duration?: number;
+  /**
+   * Color of the border, can be a single color or an array of colors
+   * @default "#000000"
+   */
+  shineColor?: string | string[];
+}
+
+/**
+ * Shine Border
+ *
+ * An animated background border effect component with configurable properties.
+ */
+export function ShineBorder({
+  borderWidth = 1,
+  duration = 14,
+  shineColor = "#000000",
+  className,
+  style,
+  ...props
+}: ShineBorderProps) {
+  return (
+    <div
+      style={
+        {
+          "--border-width": `${borderWidth}px`,
+          "--duration": `${duration}s`,
+          backgroundImage: `radial-gradient(transparent,transparent, ${
+            Array.isArray(shineColor) ? shineColor.join(",") : shineColor
+          },transparent,transparent)`,
+          backgroundSize: "300% 300%",
+          mask: `linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)`,
+          WebkitMask: `linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)`,
+          WebkitMaskComposite: "xor",
+          maskComposite: "exclude",
+          padding: "var(--border-width)",
+          ...style,
+        } as React.CSSProperties
+      }
+      className={cn(
+        "pointer-events-none absolute inset-0 size-full rounded-[inherit] will-change-[background-position] motion-safe:animate-shine",
+        className,
+      )}
+      {...props}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add a global `<Header>` with animated brand, links and theme toggle
- provide a consistent `<BackButton>` using Magic UI shine border
- create collapsible `<DashboardSidebar>` for dashboard pages
- rework bot creation into a multi‑step form with animated buttons
- refactor home page to use shared theme toggle

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6840b9569b6883248820e58b6f9b5ff5