### PR TITLE
Improve landing hero and dashboard UX

### DIFF
--- a/app/dashboard/account/page.tsx
+++ b/app/dashboard/account/page.tsx
@@ -1,0 +1,3 @@
+export default function AccountPage() {
+  return <div className="p-4">My account</div>;
+}

--- a/app/dashboard/bots/[botId]/page.tsx
+++ b/app/dashboard/bots/[botId]/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../../bots/[botId]/page';

--- a/app/dashboard/bots/new/page.tsx
+++ b/app/dashboard/bots/new/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../../bots/new/page';

--- a/app/dashboard/bots/page.tsx
+++ b/app/dashboard/bots/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../bots/page';

--- a/app/dashboard/feedback/page.tsx
+++ b/app/dashboard/feedback/page.tsx
@@ -1,0 +1,3 @@
+export default function FeedbackPage() {
+  return <div className="p-4">Send us your feedback!</div>;
+}

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,0 +1,11 @@
+import type { ReactNode } from 'react';
+import DashboardSidebar from '@/components/DashboardSidebar';
+
+export default function DashboardLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex min-h-screen">
+      <DashboardSidebar />
+      <div className="flex-1 p-4">{children}</div>
+    </div>
+  );
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,15 +1,13 @@
+"use client";
 import Link from 'next/link';
 import { mockBots } from '@/lib/mock/bots';
 import { mockUsers } from '@/lib/mock/users';
-import DashboardSidebar from '@/components/DashboardSidebar';
 import { BoxReveal } from '@/components/magicui/box-reveal';
 
 export default function Dashboard() {
   const user = mockUsers[0];
   return (
-    <main className="container mx-auto flex gap-4 p-4">
-      <DashboardSidebar />
-      <div className="flex-1 space-y-8">
+    <div className="space-y-8">
         <BoxReveal width="100%">
           <h1 className="text-3xl font-bold">Hola, {user.name}</h1>
         </BoxReveal>
@@ -18,7 +16,7 @@ export default function Dashboard() {
           <section>
             <div className="mb-2 flex items-center justify-between">
               <h2 className="text-xl font-semibold">Tus Bots</h2>
-              <Link href="/bots/new" className="btn btn-sm btn-primary">
+              <Link href="/dashboard/bots/new" className="btn btn-sm btn-primary">
                 Crear nuevo bot
               </Link>
             </div>
@@ -27,7 +25,7 @@ export default function Dashboard() {
                 <li key={bot.id} className="card bg-base-100 shadow">
                   <div className="card-body flex-row items-center justify-between p-4">
                     <span>{bot.name}</span>
-                    <Link href={`/bots/${bot.id}`} className="link-hover link">
+                    <Link href={`/dashboard/bots/${bot.id}`} className="link-hover link">
                       Ver
                     </Link>
                   </div>
@@ -48,6 +46,5 @@ export default function Dashboard() {
           </section>
         </BoxReveal>
       </div>
-    </main>
   );
 }

--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -1,0 +1,3 @@
+export default function SettingsPage() {
+  return <div className="p-4">Settings coming soon</div>;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,18 +4,20 @@ import Link from 'next/link';
 import { FlickeringGrid } from '@/components/magicui/flickering-grid';
 import { BentoGrid, BentoGridItem } from '@/components/magicui/bento-grid';
 import { TypingAnimation } from '@/components/magicui/typing-animation';
-import { ScrollBasedVelocity } from '@/components/magicui/scroll-based-velocity';
 import { DotPattern } from '@/components/magicui/dot-pattern';
+import { ScrollBasedVelocity } from '@/components/magicui/scroll-based-velocity';
 import { ShimmerButton } from '@/components/magicui/shimmer-button';
 import { BoxReveal } from '@/components/magicui/box-reveal';
-import ThemeToggle from '@/components/ThemeToggle';
 import {
   AlarmClock,
   UploadCloud,
   Handshake,
   Settings,
   Plug,
+  Instagram,
+  Youtube,
 } from 'lucide-react';
+import TikTokIcon from '@/components/icons/TikTok';
 
 export default function Home() {
 
@@ -28,11 +30,8 @@ export default function Home() {
         <div className="relative z-10 hero-content text-center">
           <div className="max-w-md space-y-4">
             <TypingAnimation as="h1" className="text-5xl font-bold">
-              Atendor
+              Build your own chatbot in seconds with Atendor.
             </TypingAnimation>
-            <ScrollBasedVelocity className="py-2 text-lg" defaultVelocity={1}>
-              Build your own agent bot in seconds.
-            </ScrollBasedVelocity>
             <Link href="/signup">
               <ShimmerButton className="px-6 py-3">Get started free</ShimmerButton>
             </Link>
@@ -121,20 +120,35 @@ export default function Home() {
         </BoxReveal>
       </section>
 
+      {/* Scroll headline */}
+      <section className="overflow-hidden py-16">
+        <ScrollBasedVelocity className="text-center" defaultVelocity={3}>
+          Build your bot agent in seconds
+        </ScrollBasedVelocity>
+      </section>
+
       {/* Footer */}
-      <footer className="footer footer-center bg-base-200 p-4">
-        <nav className="grid grid-flow-col gap-4">
-          <Link href="/login" className="link-hover link">
-            Ingresar
-          </Link>
-          <Link href="/signup" className="link-hover link">
-            Registro
-          </Link>
-          <Link href="/dashboard" className="link-hover link">
-            Dashboard
-          </Link>
-        </nav>
-        <ThemeToggle />
+      <footer className="footer bg-base-200 text-base-content">
+        <div className="container mx-auto grid grid-cols-1 items-center justify-between gap-4 py-6 md:grid-cols-2">
+          <p className="justify-self-start">© Atendor 2025 – All rights reserved</p>
+          <nav className="justify-self-end flex flex-wrap items-center gap-4">
+            <Link href="/privacy" className="link-hover link">
+              Privacy Policy
+            </Link>
+            <Link href="/terms" className="link-hover link">
+              Terms
+            </Link>
+            <Link href="https://instagram.com" className="link-hover" aria-label="Instagram">
+              <Instagram className="h-5 w-5" />
+            </Link>
+            <Link href="https://tiktok.com" className="link-hover" aria-label="TikTok">
+              <TikTokIcon className="h-5 w-5" />
+            </Link>
+            <Link href="https://youtube.com" className="link-hover" aria-label="YouTube">
+              <Youtube className="h-5 w-5" />
+            </Link>
+          </nav>
+        </div>
       </footer>
     </main>
   );

--- a/components/DashboardSidebar.tsx
+++ b/components/DashboardSidebar.tsx
@@ -1,17 +1,21 @@
 "use client";
 import Link from 'next/link';
 import { useState } from 'react';
+import { usePathname } from 'next/navigation';
 import { Menu, X } from 'lucide-react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion } from 'framer-motion';
+import ThemeToggle from './ThemeToggle';
 
 const navItems = [
-  { href: '/dashboard', label: 'My Bots' },
-  { href: '/bots/new', label: 'Create Bot' },
+  { href: '/dashboard/bots', label: 'My Bots' },
+  { href: '/dashboard/bots/new', label: 'Create Bot' },
   { href: '/dashboard/settings', label: 'Settings' },
-  { href: '/help', label: 'Help / Feedback' },
+  { href: '/dashboard/account', label: 'My Account' },
+  { href: '/dashboard/feedback', label: 'Feedback' },
 ];
 
 export default function DashboardSidebar() {
+  const pathname = usePathname();
   const [open, setOpen] = useState(false);
 
   return (
@@ -22,30 +26,27 @@ export default function DashboardSidebar() {
       >
         {open ? <X /> : <Menu />}
       </button>
-      <AnimatePresence>
-        {(open || typeof window === 'undefined') && (
-          <motion.aside
-            initial={{ x: -260 }}
-            animate={{ x: 0 }}
-            exit={{ x: -260 }}
-            transition={{ type: 'spring', stiffness: 260, damping: 20 }}
-            className="fixed inset-y-0 left-0 z-20 w-56 bg-base-100 p-4 shadow sm:static sm:translate-x-0"
-          >
+      <motion.aside
+        className={`fixed inset-y-0 left-0 z-20 flex w-56 flex-col bg-base-100 p-4 shadow transition-transform sm:static sm:translate-x-0 ${open ? 'translate-x-0' : '-translate-x-full sm:translate-x-0'}`}
+      >
             <nav className="space-y-2">
               {navItems.map((item) => (
-                <Link
-                  key={item.href}
-                  href={item.href}
-                  className="block rounded px-2 py-2 transition hover:bg-base-200"
-                  onClick={() => setOpen(false)}
-                >
-                  {item.label}
-                </Link>
+                <motion.div whileHover={{ scale: 1.05 }} key={item.href}>
+                  <Link
+                    href={item.href}
+                    className={`block rounded px-2 py-2 transition hover:bg-base-200 ${pathname === item.href ? 'bg-base-200' : ''}`}
+                    onClick={() => setOpen(false)}
+                  >
+                    {item.label}
+                  </Link>
+                </motion.div>
               ))}
             </nav>
-          </motion.aside>
-        )}
-      </AnimatePresence>
+            <div className="mt-auto space-y-2 pt-4">
+              <ThemeToggle />
+              <button className="btn btn-ghost btn-sm w-full">Logout</button>
+            </div>
+      </motion.aside>
     </div>
   );
 }

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,18 +1,19 @@
 "use client";
 import Link from 'next/link';
 import { useState } from 'react';
+import { usePathname } from 'next/navigation';
 import ThemeToggle from './ThemeToggle';
 import BackButton from './BackButton';
 import { AnimatedShinyText } from '@/components/magicui/animated-shiny-text';
-import { ShimmerButton } from '@/components/magicui/shimmer-button';
 
 export default function Header() {
+  const pathname = usePathname();
   const [loggedIn] = useState(false);
   return (
     <header className="border-b bg-base-100">
       <nav className="container mx-auto flex items-center justify-between p-4">
         <div className="flex items-center gap-4">
-          <BackButton className="hidden sm:inline-flex" />
+          {pathname !== '/' && <BackButton className="hidden sm:inline-flex" />}
           <Link href="/" className="font-bold">
             <AnimatedShinyText className="text-2xl">Atendor</AnimatedShinyText>
           </Link>
@@ -31,8 +32,8 @@ export default function Header() {
               <Link href="/login" className="link-hover link">
                 Login
               </Link>
-              <Link href="/signup">
-                <ShimmerButton className="px-6 py-3">Get started free</ShimmerButton>
+              <Link href="/signup" className="link-hover link">
+                Registrarse
               </Link>
             </>
           )}

--- a/components/icons/TikTok.tsx
+++ b/components/icons/TikTok.tsx
@@ -1,0 +1,12 @@
+export default function TikTokIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="M12.8 2h3.2a5.9 5.9 0 0 0 5.9 5.9v3.1a9 9 0 0 1-5.9-2.1v7.8a7 7 0 1 1-7-7v3.2a3.8 3.8 0 1 0 3.8 3.8V2Z" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- tweak header CTA and back button logic
- revamp landing hero and add scroll headline section
- update footer with policy links and social icons
- implement reusable dashboard sidebar and layout
- add dashboard route placeholders and TikTok icon

## Testing
- `pnpm install`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684178e57ff88324a8a8408a1394fb65