### PR TITLE
Fix missing icon dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@supabase/supabase-js": "^2.39.6",
     "clsx": "^2.1.0",
     "daisyui": "^4.9.0",
+    "@radix-ui/react-icons": "^1.3.2",
     "lucide-react": "^0.372.0",
     "motion": "^11.0.0",
     "magicui": "github:magicuidesign/magicui",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     dependencies:
+      '@radix-ui/react-icons':
+        specifier: ^1.3.2
+        version: 1.3.2(react@18.2.0)
       '@supabase/auth-helpers-nextjs':
         specifier: ^0.7.3
         version: 0.7.4(@supabase/supabase-js@2.49.10)
@@ -4485,6 +4488,10 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.1.6
+
+  '@radix-ui/react-icons@1.3.2(react@18.2.0)':
+    dependencies:
+      react: 18.2.0
 
   '@radix-ui/react-icons@1.3.2(react@18.3.1)':
     dependencies:


### PR DESCRIPTION
## Summary
- add `@radix-ui/react-icons` to dependencies

## Testing
- `pnpm install`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_6842b39605e48324b55df8ac4a2a5708